### PR TITLE
Ikke oppdatere status når komponent ikke er aktiv

### DIFF
--- a/src/app/elements/rangeInput/rangeInput.less
+++ b/src/app/elements/rangeInput/rangeInput.less
@@ -9,7 +9,7 @@
 		border: @thumbBorderWidth solid @thumbBorder;
 		height: @thumbSize;
 		width: @thumbSize;
-		margin-top: -1 * @thumbSize/2 + @thumbBorderWidth;
+		margin-top: -1 * @thumbSize / 2 + @thumbBorderWidth;
 		cursor: pointer;
 	}
 	.track() {


### PR DESCRIPTION
RangeInput leste oppdateringer (aria-live) av verdien når den ikke var aktiv - dvs. når verdien ble satt utenfor komponenten. Denne fikser dette ved at komponenten selv sjekker om den er aktiv eller ikke, og informerer kun når den er aktiv.